### PR TITLE
Overload create method for builder with default user agent + fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It brings in support for using an API key as per [this documentation](https://ha
 
 It brings in support for using an API key as per [this documentation](https://haveibeenpwned.com/API/v3)
 
-**Version 2.0 is still avaialble for download from GitHub and in Maven Central**
+**Version 2.0 is still available for download from GitHub and in Maven Central**
 
 Version 2.0 brings the following changes: 
 * The API supports padding for pwnd passwords (see https://www.troyhunt.com/enhancing-pwned-passwords-privacy-with-padding/)
@@ -25,7 +25,7 @@ Version 2.0 brings the following changes:
   * The URL to use for breach data (advanced feature, don't use)
 * The builder pattern must be used 
 
-**Version 1.1 is still avaialble for download from GitHub and in Maven Central**
+**Version 1.1 is still available for download from GitHub and in Maven Central**
 
   
 # Getting the API

--- a/src/main/java/me/legrange/haveibeenpwned/HaveIBeenPwndBuilder.java
+++ b/src/main/java/me/legrange/haveibeenpwned/HaveIBeenPwndBuilder.java
@@ -19,6 +19,15 @@ public final class HaveIBeenPwndBuilder {
     private String userAgent = DEFAULT_USER_AGENT;
     private Proxy proxy = null;
 
+
+    /** Create a new builder with default user agent.
+     *
+     * @return The builder
+     */
+    public static HaveIBeenPwndBuilder create() {
+        return create(DEFAULT_USER_AGENT);
+    }
+
     /** Create a new builder.
      *
      * @param userAgent The user agent to use when connecting


### PR DESCRIPTION
Greetings! If I will follow the instructions from README:

```java
HaveIBeenPwndApi hibp = HaveIBeenPwndBuilder().create().build();
```

it will not compile due to changes to the `create()` method and the requirement to provide the user agent. 

I've overloaded the builder to keep using the default user agent to avoid creating a bit more messy code like this below:

```java
HaveIBeenPwndApi hibp = HaveIBeenPwndBuilder().create("HaveIBeenPwndJava-v1").build();
```